### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,9 +346,9 @@ in `settings.py`, the rest could be overwritten if required, as described below:
 - `SECURE` - whether your Cloudinary files should be server over HTTP or HTTPS, HTTPS is the default, set it to False
   to switch to HTTP
 - `MEDIA_TAG` - name assigned to your all media files, it has to be different than `STATIC_TAG`, usually you don't
-  need to worry about this setting, it is useful when you have several websites which use the same Cloudinary acount, when
+  need to worry about this setting, it is useful when you have several websites which use the same Cloudinary account, when
   you should set it unique to distinguish it from other websites,
-- `INVALID_VIDEO_ERROR_MESSAGE` - error message which will be desplayed in user's form when one tries to upload non-video
+- `INVALID_VIDEO_ERROR_MESSAGE` - error message which will be displayed in user's form when one tries to upload non-video
   file in video field
 - `EXCLUDE_DELETE_ORPHANED_MEDIA_PATHS` - looked by `deleteorphanedmedia` command, you can provide here tuple of paths
   which will never be deleted

--- a/tests/tests/test_helpers.py
+++ b/tests/tests/test_helpers.py
@@ -65,7 +65,7 @@ def import_mock():
 
 def get_save_calls_counter_in_postprocess_of_adjustable_file():
     """
-    Since Django 1.11, postprocess algorythm has been changed for css files
+    Since Django 1.11, postprocess algorithm has been changed for css files
     is such a way that they save is called 4 times total.
     It must be taken into consideration in unittests.
     Hopefully this will be removed at some point once Django introduces optimization
@@ -80,7 +80,7 @@ def get_save_calls_counter_in_postprocess_of_adjustable_file():
 
 def get_postprocess_counter_of_adjustable_file():
     """
-    Since Django 1.11, postprocess algorythm has been changed for css files
+    Since Django 1.11, postprocess algorithm has been changed for css files
     is such a way that they are postprocessed twice.
     """
     if version.get_complete_version() >= (1, 11):


### PR DESCRIPTION
There are small typos in:
- README.md
- tests/tests/test_helpers.py

Fixes:
- Should read `algorithm` rather than `algorythm`.
- Should read `displayed` rather than `desplayed`.
- Should read `account` rather than `acount`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md