### PR TITLE
Refactor

### DIFF
--- a/cloudinary_storage/app_settings.py
+++ b/cloudinary_storage/app_settings.py
@@ -1,3 +1,6 @@
+# Kept for reference, will be removed when all functionality is implemented somewhere else.
+
+
 import importlib
 import os
 import sys

--- a/cloudinary_storage/base.py
+++ b/cloudinary_storage/base.py
@@ -1,11 +1,16 @@
 import os
+import requests
 
 import cloudinary
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
+from django.core.files.uploadedfile import UploadedFile
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+from .helpers import get_resources_by_path
+
+
 user_settings = getattr(settings, 'CLOUDINARY_STORAGE', {})
 
 def setting(name, default=None):
@@ -65,6 +70,7 @@ class BaseStorage(Storage):
                 api_secret=self.api_secret,
                 secure=self.secure
             )
+        super().__init__()
 
     def get_default_settings(self):
         return {
@@ -76,7 +82,7 @@ class BaseStorage(Storage):
             'invalid_video_error_message': setting('INVALID_VIDEO_ERROR_NESSAGE', 'Please upload a valid video file.'),
             'exclude_delete_orphaned_media_paths': setting('EXCLUDE_DELETE_ORPHANED_MEDIA_PATHS', ()),
             'static_tag': setting('STATIC_TAG', 'static'),
-            'staticfiles_manifest_root': setting('STATICFILES_MANIFEST_ROOT', os.path.join(BASE_DIR, 'manifest')),
+            'staticfiles_manifest_root': setting('STATICFILES_MANIFEST_ROOT', os.path.join(settings.BASE_DIR, 'manifest')),
             'static_images_extensions': setting('STATIC_IMAGES_EXTENSIONS',
                                 [
                                     'jpg',
@@ -96,7 +102,7 @@ class BaseStorage(Storage):
                                     'tiff',
                                     'ico'
                                     ]),
-            'static_video_extensions': setting('STATIC_VIDEOS_EXTENSIONS',
+            'static_videos_extensions': setting('STATIC_VIDEOS_EXTENSIONS',
                                 [
                                     'mp4',
                                     'webm',
@@ -117,3 +123,92 @@ class BaseStorage(Storage):
             'magic_file_path': setting('MAGIC_FILE_PATH', 'magic'),
             'prefix': setting('PREFIX', settings.MEDIA_URL),
         }
+
+    
+    def _open(self, name, mode='rb'):
+        url = self._get_url(name)
+        response = requests.get(url)
+        if response.status_code == 404:
+            raise IOError
+        response.raise_for_status()
+        file = ContentFile(response.content)
+        file.name = name
+        file.mode = mode
+        return file
+
+    def _upload(self, name, content):
+        options = {'use_filename': True, 'resource_type': self.RESOURCE_TYPE, 'tags': self.TAG}
+        folder = os.path.dirname(name)
+        if folder:
+            options['folder'] = folder
+        return cloudinary.uploader.upload(content, **options)
+
+    def _save(self, name, content):
+        name = self._normalise_name(name)
+        name = self._prepend_prefix(name)
+        content = UploadedFile(content, name)
+        response = self._upload(name, content)
+        return response['public_id']
+
+    def delete(self, name):
+        response = cloudinary.uploader.destroy(name, invalidate=True, resource_type=self.RESOURCE_TYPE)
+        return response['result'] == 'ok'
+
+    def _get_url(self, name):
+        name = self._prepend_prefix(name)
+        cloudinary_resource = cloudinary.CloudinaryResource(name, default_resource_type=self.RESOURCE_TYPE)
+        return cloudinary_resource.url
+
+    def url(self, name):
+        return self._get_url(name)
+
+    def exists(self, name):
+        url = self._get_url(name)
+        response = requests.head(url)
+        if response.status_code == 404:
+            return False
+        response.raise_for_status()
+        return True
+
+    def size(self, name):
+        url = self._get_url(name)
+        response = requests.head(url)
+        if response.status_code == 200:
+            return int(response.headers['content-length'])
+        else:
+            return None
+
+    def get_available_name(self, name, max_length=None):
+        if max_length is None:
+            return name
+        else:
+            return name[:max_length]
+
+    def _normalize_path(self, path):
+        if path != '' and not path.endswith('/'):
+            path += '/'
+        return path
+
+    def _prepend_prefix(self, name):
+        prefix = self.prefix.lstrip('/')
+        prefix = self._normalize_path(prefix)
+        if not name.startswith(prefix):
+            name = prefix + name
+        return name
+
+    def listdir(self, path):
+        path = self._normalize_path(path)
+        resources = get_resources_by_path(self.RESOURCE_TYPE, self.TAG, path)
+        directories = set()
+        files = []
+        for resource in resources:
+            resource_tail = resource.replace(path, '', 1)
+            if '/' in resource_tail:
+                directory = resource_tail.split('/', 1)[0]
+                directories.add(directory)
+            else:
+                files.append(resource_tail)
+        return list(directories), files
+
+    def _normalise_name(self, name):
+        return name.replace('\\', '/')

--- a/cloudinary_storage/base.py
+++ b/cloudinary_storage/base.py
@@ -1,0 +1,119 @@
+import os
+
+import cloudinary
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import Storage
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+user_settings = getattr(settings, 'CLOUDINARY_STORAGE', {})
+
+def setting(name, default=None):
+    """
+    Helper function to get a setting by name. If setting doesn't exists
+    it will return a default.
+
+    :param name: Name of setting
+    :type name: str
+    :param default: Value if setting is unfound
+    :returns: Setting's value
+    """
+    return user_settings.get(name, default)
+
+
+class BaseStorage(Storage):
+    RESOURCE_TYPES = {
+        'IMAGE': 'image',
+        'RAW': 'raw',
+        'VIDEO': 'video'
+    }
+
+    def __init__(self, **settings):
+        default_settings = self.get_default_settings()
+
+        for name, value in default_settings.items():
+            if not hasattr(self, name):
+                setattr(self, name, value)
+
+        for name, value in settings.items():
+            if name not in default_settings:
+                raise ImproperlyConfigured(
+                    "Invalid setting '{}' for {}".format(
+                        name,
+                        self.__class__.__name__,
+                    )
+                )
+            setattr(self, name, value)
+
+        if not self.cloud_name or not self.api_key or not self.api_secret:
+            if not os.environ.get('CLOUDINARY_URL'):
+                raise ImproperlyConfigured("""
+    In order to use cloudinary storage, you need to do ONE of the following:
+    
+    provide OPTIONS dictionary with cloud_name, api_secret, and api_key in  the settings under STORAGES["default"]
+    OR
+    provide CLOUDINARY_STORAGE dictionary with CLOUD_NAME, API_SECRET and API_KEY in the settings 
+    OR
+    set CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET environment variables
+    OR
+    set CLOUDINARY_URL environment variable""")
+            return
+        else:
+            cloudinary.config(
+                cloud_name=self.cloud_name,
+                api_key=self.api_key,
+                api_secret=self.api_secret,
+                secure=self.secure
+            )
+
+    def get_default_settings(self):
+        return {
+            'cloud_name': setting('CLOUD_NAME', os.environ.get('CLOUDINARY_CLOUD_NAME')),
+            'api_key': setting('API_KEY', os.environ.get('CLOUDINARY_API_KEY')),
+            'api_secret': setting('API_SECRET', os.environ.get('CLOUDINARY_API_SECRET')),
+            'secure': setting('SECURE', True),
+            'media_tag': setting('MEDIA_TAG', 'media'),
+            'invalid_video_error_message': setting('INVALID_VIDEO_ERROR_NESSAGE', 'Please upload a valid video file.'),
+            'exclude_delete_orphaned_media_paths': setting('EXCLUDE_DELETE_ORPHANED_MEDIA_PATHS', ()),
+            'static_tag': setting('STATIC_TAG', 'static'),
+            'staticfiles_manifest_root': setting('STATICFILES_MANIFEST_ROOT', os.path.join(BASE_DIR, 'manifest')),
+            'static_images_extensions': setting('STATIC_IMAGES_EXTENSIONS',
+                                [
+                                    'jpg',
+                                    'jpe',
+                                    'jpeg',
+                                    'jpc',
+                                    'jp2',
+                                    'j2k',
+                                    'wdp',
+                                    'jxr',
+                                    'hdp',
+                                    'png',
+                                    'gif',
+                                    'webp',
+                                    'bmp',
+                                    'tif',
+                                    'tiff',
+                                    'ico'
+                                    ]),
+            'static_video_extensions': setting('STATIC_VIDEOS_EXTENSIONS',
+                                [
+                                    'mp4',
+                                    'webm',
+                                    'flv',
+                                    'mov',
+                                    'ogv',
+                                    '3gp',
+                                    '3g2',
+                                    'wmv',
+                                    'mpeg',
+                                    'flv',
+                                    'mkv',
+                                    'avi'
+                                ]),
+
+            # used only on Windows, see https://github.com/ahupp/python-magic#dependencies for your reference
+
+            'magic_file_path': setting('MAGIC_FILE_PATH', 'magic'),
+            'prefix': setting('PREFIX', settings.MEDIA_URL),
+        }

--- a/cloudinary_storage/management/commands/collectstatic.py
+++ b/cloudinary_storage/management/commands/collectstatic.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.management.commands import collectstatic
+from django.core.files.storage import storages
 from django.conf import settings
 
 
@@ -24,6 +25,6 @@ class Command(collectstatic.Command):
         Overwritten to execute only with --upload-unhashed-files param or StaticCloudinaryStorage.
         Otherwise only hashed files will be uploaded during postprocessing.
         """
-        if (settings.STATICFILES_STORAGE == 'cloudinary_storage.storage.StaticCloudinaryStorage' or
+        if (storages['staticfiles'] == 'cloudinary_storage.storage.StaticCloudinaryStorage' or
                 self.upload_unhashed_files):
             super(Command, self).copy_file(path, prefixed_path, source_storage)

--- a/cloudinary_storage/storage.py
+++ b/cloudinary_storage/storage.py
@@ -12,12 +12,9 @@ from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import HashedFilesMixin, ManifestFilesMixin
 from django.core.files.base import ContentFile, File
 from django.core.files.storage import FileSystemStorage
-from django.core.files.uploadedfile import UploadedFile
 from django.utils.deconstruct import deconstructible
 
-# from . import app_settings
 from .base import BaseStorage
-from .helpers import get_resources_by_path
 
 
 @deconstructible
@@ -27,94 +24,6 @@ class MediaCloudinaryStorage(BaseStorage):
         super().__init__(**settings)
         self.TAG = self.media_tag
         self.RESOURCE_TYPE = self.RESOURCE_TYPES['IMAGE']
-
-    def _open(self, name, mode='rb'):
-        url = self._get_url(name)
-        response = requests.get(url)
-        if response.status_code == 404:
-            raise IOError
-        response.raise_for_status()
-        file = ContentFile(response.content)
-        file.name = name
-        file.mode = mode
-        return file
-
-    def _upload(self, name, content):
-        options = {'use_filename': True, 'resource_type': self.RESOURCE_TYPE, 'tags': self.TAG}
-        folder = os.path.dirname(name)
-        if folder:
-            options['folder'] = folder
-        return cloudinary.uploader.upload(content, **options)
-
-    def _save(self, name, content):
-        name = self._normalise_name(name)
-        name = self._prepend_prefix(name)
-        content = UploadedFile(content, name)
-        response = self._upload(name, content)
-        return response['public_id']
-
-    def delete(self, name):
-        response = cloudinary.uploader.destroy(name, invalidate=True, resource_type=self.RESOURCE_TYPE)
-        return response['result'] == 'ok'
-
-    def _get_url(self, name):
-        name = self._prepend_prefix(name)
-        cloudinary_resource = cloudinary.CloudinaryResource(name, default_resource_type=self.RESOURCE_TYPE)
-        return cloudinary_resource.url
-
-    def url(self, name):
-        return self._get_url(name)
-
-    def exists(self, name):
-        url = self._get_url(name)
-        response = requests.head(url)
-        if response.status_code == 404:
-            return False
-        response.raise_for_status()
-        return True
-
-    def size(self, name):
-        url = self._get_url(name)
-        response = requests.head(url)
-        if response.status_code == 200:
-            return int(response.headers['content-length'])
-        else:
-            return None
-
-    def get_available_name(self, name, max_length=None):
-        if max_length is None:
-            return name
-        else:
-            return name[:max_length]
-
-    def _normalize_path(self, path):
-        if path != '' and not path.endswith('/'):
-            path += '/'
-        return path
-
-    def _prepend_prefix(self, name):
-        prefix = self.prefix.lstrip('/')
-        prefix = self._normalize_path(prefix)
-        if not name.startswith(prefix):
-            name = prefix + name
-        return name
-
-    def listdir(self, path):
-        path = self._normalize_path(path)
-        resources = get_resources_by_path(self.RESOURCE_TYPE, self.TAG, path)
-        directories = set()
-        files = []
-        for resource in resources:
-            resource_tail = resource.replace(path, '', 1)
-            if '/' in resource_tail:
-                directory = resource_tail.split('/', 1)[0]
-                directories.add(directory)
-            else:
-                files.append(resource_tail)
-        return list(directories), files
-
-    def _normalise_name(self, name):
-        return name.replace('\\', '/')
 
 
 class RawMediaCloudinaryStorage(MediaCloudinaryStorage):
@@ -144,8 +53,8 @@ class StaticCloudinaryStorage(BaseStorage):
     and changing files could become problematic.
     """
     def __init__(self, **settings):
-        super().__init__(**settings)
         self.RESOURCE_TYPE = self.RESOURCE_TYPES['RAW']
+        super().__init__(**settings)
         self.TAG = self.static_tag
 
     def _get_resource_type(self, name):
@@ -157,9 +66,9 @@ class StaticCloudinaryStorage(BaseStorage):
         extension = self._get_file_extension(name)
         if extension is None:
             return self.RESOURCE_TYPE
-        elif extension in self.STATIC_IMAGES_EXTENSIONS:
+        elif extension in self.static_images_extensions:
             return self.RESOURCE_TYPES['IMAGE']
-        elif extension in self.STATIC_VIDEOS_EXTENSIONS:
+        elif extension in self.static_videos_extensions:
             return self.RESOURCE_TYPES['VIDEO']
         else:
             return self.RESOURCE_TYPE
@@ -253,13 +162,13 @@ class ManifestCloudinaryStorage(FileSystemStorage):
     including Heroku and AWS Elastic Beanstalk.
     """
     def __init__(self, location=None, base_url=None, *args, **kwargs):
-        super(ManifestCloudinaryStorage, self).__init__(location, base_url, *args, **kwargs)
+        super().__init__(location, base_url, *args, **kwargs)
 
 
 class HashCloudinaryMixin(object):
     def __init__(self, *args, **kwargs):
-        self.manifest_storage = ManifestCloudinaryStorage(location=self.staticfiles_manifest_root) # "location" value comes from StaticCloudinaryStorage, as both it and this class are parent classes of StaticHashedCloudinaryStorage class.
         super(HashCloudinaryMixin, self).__init__(*args, **kwargs)
+        self.manifest_storage = ManifestCloudinaryStorage(location = self.staticfiles_manifest_root)
 
     def hashed_name(self, name, content=None, filename=None):
         parsed_name = urlsplit(unquote(name))
@@ -328,6 +237,9 @@ class HashCloudinaryMixin(object):
     stored_name = HashedFilesMixin.stored_name
 
 
-class StaticHashedCloudinaryStorage(StaticCloudinaryStorage, HashCloudinaryMixin, ManifestFilesMixin):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+class StaticHashedCloudinaryStorage(
+        HashCloudinaryMixin,
+        ManifestFilesMixin,
+        StaticCloudinaryStorage
+    ):
+    pass


### PR DESCRIPTION
Fixing https://github.com/klis87/django-cloudinary-storage/issues/40

### This is a work in progress. I am trying to add support for django 5.1 and above by allowing the configuration of Cloudinary Storage backend through `OPTIONS` dictionary, which basically means in the storage class constructor.

In order to achieve this, I created a base class `BaseStorage` that defines an attribute for each cloudinary storage setting from app_settings.py, and allows passing their values to the class constructor, or setting them in `CLOUDINARY_STORAGE` dictionary, or with environment variables for some attributes, while keeping the desired precedence intact.

Now all storage classes (e.g. `MediaCloudinaryStorage` and `StaticCloudinaryStorage`) inherit this `BaseStorage` class, allowing them to be configured in the new django way besides the current `CLOUDINARY_STORAGE` way, thus completely eliminating the need for app_setting module (except for change detection and reloading feature which I hadn't implemented yet).

### Where I need help:

**1.** Since `MediaCloudinaryStorage` and `StaticCloudinaryStorage` are now inheriting `BaseStorage`, each instance of them has its own configuration, so configuring them in settings.py would look like:
```
STORAGES = {
    "default": {
        "BACKEND": "cloudinary_storage.storage.MediaCloudinaryStorage",
        "OPTIONS": {
            'cloud_name': 'cloud-name',
            'api_key': 'api-key',
            'api_secret': 'api-secret',
        }
    },
    'staticfiles': {
        'BACKEND': 'cloudinary_storage.storage.StaticHashedCloudinaryStorage',
        "OPTIONS": {
            'cloud_name': 'cloud-name',
            'api_key': 'api-key',
            'api_secret': 'api-secret',
        }
    },
}
```

and this is logical because each one of them is a separate storage backend, and this allows for using two different cloudinary clouds, one for media files and one for static. But it gets tricky because when omitting `OPTIONS` and having the configuration in `CLOUDINARY_STORAGE` or environment variables, both storages (or any storage class inheriting `BaseStorage`) will use the same configuration, so two different behaviors which might cause confusion for the user. And the only solution I can see is remove `CLOUDINARY_STORAGE` altogether and use different environment variables for media and static storage.

What do you think is the best approach ? or is the current behavior acceptable ?

**2.** So far, I've been dealing with numerous MRO issues that have been avoided in the original implementation, and I finally got things to work, but while I was testing the main features and making sure they are working fine so I can move to cleaning things up, fixing the tests, and finalizing the work, something didn't work properly and I don't know exactly what's going on, when I run the `collectstatic` commands, static files start getting uploaded to cloudinary and I can see them in cloudinary dashboard, but the process is very slow, I checked the uploading speed and it was 0.1 Mb/s, I don't know if it has something to do with my internet or machine, eventually, the command finish running, in the first try I got a weird connection error (possibly timeout), the second time it worked and the the manifest file (staticfiles.json) was created, but the static files didn't load correctly, I ran it again and it got stuck forever. TBH I don't know what's going on and I would appreciate someone test this on their machine and help me sort out these issues.

**3.** Do we need support for Python 2 ?
For example, super() method doesn't require passing any arguments in Python 3, but in Python 2 this will raise an exception.
So do I have to try and keep the code compatible with older Python versions ?

@klis87 I would appreciate your guidance and help for finishing this work whenever you're free, and I am ready to continue working on it once I get your feedback.